### PR TITLE
Only set node if it needs to

### DIFF
--- a/cmake/xpfunmac.cmake
+++ b/cmake/xpfunmac.cmake
@@ -2166,7 +2166,9 @@ function(xpAddCoverage)
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       )
     list(APPEND precoverage precoveragejs)
-    xpGetPkgVar(Node EXE)
+    if(NOT DEFINED NODE_EXE)
+      xpGetPkgVar(Node EXE)
+    endif()
     set(JS_SERVER_COVERAGE_FLAGS ${NODE_EXE} node_modules/nyc/bin/nyc.js --include @SRC_DIR@
       --report-dir ${CMAKE_BINARY_DIR}/coveragejs/@BUILD_TARGET@
       --temp-dir ${CMAKE_BINARY_DIR}/coveragejs/@BUILD_TARGET@/.nyc_output


### PR DESCRIPTION
By adding this check, it allows me to override where it is going to look for node, that way I don't have to get it from externpro.

You should take a look at the CI pull request. I could really use your opinion on what I have done 😆 