### PR TITLE
actpro repo obsolete, git history merged into externpro repo

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,114 @@
+name: Build Linux
+on:
+  workflow_call:
+    inputs:
+      email:
+        required: true
+        type: string
+      runon:
+        required: false
+        type: string
+        default: "ubuntu-latest" # runs-on value (e.g., ubuntu-latest, ubuntu-24.04-arm, etc.)
+jobs:
+  devcontainer-changed:
+    runs-on: ${{ inputs.runon }}
+    outputs:
+      docker-changed: ${{ steps.filter.outputs.docker }}
+    steps:
+      -
+        uses: actions/checkout@v4
+      -
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docker:
+              - '.devcontainer/**'
+  build-docker-image:
+    needs: devcontainer-changed
+    #if: needs.devcontainer-changed.outputs.docker-changed == 'true'
+    runs-on: ${{ inputs.runon }}
+    outputs:
+      ran: true
+    steps:
+      -
+        name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      -
+        name: Configure git
+        run: |
+          touch ~/.gitconfig
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ inputs.email }}
+      -
+        name: Get docker image name
+        run: |
+          echo "DOCKER_IMAGE_NAME=$(echo $(basename ${{ github.repository }})-bld | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      -
+        name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push docker image
+        run: |
+          ./docker-compose.sh -b
+          docker tag ${{ env.DOCKER_IMAGE_NAME }}:latest ghcr.io/${{ github.repository }}/buildimage:${{ github.sha }}
+          docker push ghcr.io/${{ github.repository }}/buildimage:${{ github.sha }}
+          docker images
+  build:
+    needs: [devcontainer-changed, build-docker-image]
+    if: ${{ needs.devcontainer-changed.outputs.docker-changed == 'false' || always() && needs.build-docker-image.result == 'success' }}
+    runs-on: ${{ inputs.runon }}
+    env:
+      CMAKE_PRESET: Linux
+    container:
+      image: ghcr.io/${{ github.repository }}/buildimage:${{ github.sha }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      -
+        name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # fetches all history
+          fetch-tags: true # explicitly fetches tags
+          submodules: true
+      -
+        name: CMake Configure
+        run: cmake --preset=${{ env.CMAKE_PRESET }}
+      -
+        name: CMake Workflow
+        run: cmake --workflow --preset=${{ env.CMAKE_PRESET }}
+      -
+        name: Upload CMake logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmake-logs
+          path: |
+            _bld-${{ env.CMAKE_PRESET }}/CMakeFiles/CMakeOutput.log
+            _bld-${{ env.CMAKE_PRESET }}/CMakeFiles/CMakeError.log
+      -
+        name: Find devel package tarball
+        id: find_tarball
+        shell: bash
+        run: |
+          file=$(pwd)/$(ls _bld-${{ env.CMAKE_PRESET }}/${{ github.event.repository.name }}*-devel.tar.xz)
+          if [[ ! -f "$file" ]]; then
+            echo "Tarball not found!" >&2
+            exit 1
+          fi
+          echo "filepath=$file" >> $GITHUB_OUTPUT
+          echo "filename=$(basename $file)" >> $GITHUB_OUTPUT
+        working-directory: ${{ github.workspace }}
+      -
+        name: Upload devel tarball artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.find_tarball.outputs.filename }}
+          path: ${{ steps.find_tarball.outputs.filepath }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,56 @@
+name: Build Windows
+on:
+  workflow_call:
+jobs:
+  build:
+    runs-on: windows-2022
+    env:
+      CMAKE_PRESET: Windows
+    steps:
+      -
+        name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # fetches all history
+          fetch-tags: true # explicitly fetches tags
+          submodules: true
+      -
+        name: CMake Configure
+        run: cmake --preset=${{ env.CMAKE_PRESET }}
+      -
+        name: CMake Workflow
+        run: cmake --workflow --preset=${{ env.CMAKE_PRESET }}
+      -
+        name: Upload CMake logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmake-logs
+          path: |
+            _bld-${{ env.CMAKE_PRESET }}/CMakeFiles/CMakeOutput.log
+            _bld-${{ env.CMAKE_PRESET }}/CMakeFiles/CMakeError.log
+      -
+        name: Find devel package tarball
+        id: find_tarball
+        shell: bash
+        run: |
+          file=$(pwd)/$(ls _bld-${{ env.CMAKE_PRESET }}/${{ github.event.repository.name }}*-devel.tar.xz)
+          if [[ ! -f "$file" ]]; then
+            echo "Tarball not found!" >&2
+            exit 1
+          fi
+          echo "filepath=$file" >> $GITHUB_OUTPUT
+          echo "filename=$(basename $file)" >> $GITHUB_OUTPUT
+        working-directory: ${{ github.workspace }}
+      -
+        name: Convert Git Bash path to Windows path
+        id: convert_path
+        shell: pwsh
+        run: |
+          $windowsPath = '${{ steps.find_tarball.outputs.filepath }}' -replace '^/([a-zA-Z])/', '$1:/' -replace '/', '\'
+          echo "windows_path=$windowsPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+      -
+        name: Upload devel tarball artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.find_tarball.outputs.filename }}
+          path: ${{ steps.convert_path.outputs.windows_path }}

--- a/.github/workflows/buildpro.yml
+++ b/.github/workflows/buildpro.yml
@@ -1,0 +1,109 @@
+name: Build docker buildpro image
+on:
+  workflow_call:
+    inputs:
+      img:
+        required: true
+        type: string
+      platforms:
+        required: false
+        type: string
+        default: "local" # use platform that invokes the build
+jobs:
+  buildpro:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    env:
+      REGISTRY: ghcr.io
+    steps:
+      -
+        name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # fetches all history
+          fetch-tags: true # explicitly fetches tags
+          submodules: true
+      -
+        name: Determine tags
+        id: tags
+        run: |
+          gtag=`git describe --tags`
+          if [ -n "$(git status --porcelain --untracked=no)" ] || [[ ${gtag} == *"-g"* ]]; then
+            gtag=latest
+          fi
+          echo "tag=$gtag" >> $GITHUB_OUTPUT
+          echo "latest=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.img }}:latest" >> $GITHUB_OUTPUT
+          echo "tagged=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.img }}:$gtag" >> $GITHUB_OUTPUT
+        working-directory: ${{ github.workspace }}
+      -
+        name: Report before build
+        run: |
+          echo "img: ${{ inputs.img }}"
+          echo "latest: ${{ steps.tags.outputs.latest }}"
+          echo "tagged: ${{ steps.tags.outputs.tagged }}"
+          docker pull ${{ steps.tags.outputs.latest }}
+          docker images
+          docker rmi ${{ steps.tags.outputs.latest }}
+      -
+        name: Set up Docker Buildx (for multi-platform builds)
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Set up QEMU (for emulating different CPU architectures)
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Authenticate GitHub Container Registry (ghcr)
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Extract metadata (tags, labels) for Docker
+        id: metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.img }}
+      -
+        name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ github.workspace }}/public
+          file: ${{ github.workspace }}/public/${{ inputs.img }}.dockerfile
+          build-args: |
+            BPROTAG=${{ steps.tags.outputs.tag }}
+          platforms: ${{ inputs.platforms }}
+          provenance: false
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: |
+            ${{ steps.tags.outputs.latest }}
+            ${{ steps.tags.outputs.tagged }}
+          push: true
+      -
+        name: Attest Docker image
+        uses: actions/attest-build-provenance@v2
+        id: attest
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.img }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: false
+      -
+        name: Report after build
+        run: |
+          docker pull ${{ steps.tags.outputs.latest }}
+          docker images
+          docker rmi ${{ steps.tags.outputs.latest }}
+      -
+        name: Delete untagged images from ghcr
+        uses: snok/container-retention-policy@v3.0.0
+        with:
+          account: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: ${{ github.event.repository.name }}/${{ inputs.img }}
+          tag-selection: untagged
+          cut-off: 1m
+          dry-run: false


### PR DESCRIPTION
I came to the realization that the shared workflows (GitHub Actions) could live in the externpro repo https://github.com/externpro/externpro and didn't need to be in a separate actpro repo https://github.com/externpro/actpro

I brought the commit history from actpro with the following commands in a clone of the externpro repo -- the only conflict is with the LICENSE file (2024 vs 2025) and the conflict resolution was trivial
```
git remote add actpro https://github.com/externpro/actpro
git fetch --all
git checkout -b actpro
git merge --allow-unrelated-histories actpro/main
vi LICENSE
git add LICENSE
git commit
```